### PR TITLE
removed dead imports

### DIFF
--- a/orders/src/index.ts
+++ b/orders/src/index.ts
@@ -4,7 +4,6 @@ import { natsWrapper } from "./nats-wrapper";
 import { TicketCreatedListener } from "./events/listeners/ticket-created-listener";
 import { TicketUpdatedListener } from "./events/listeners/ticket-updated-listener";
 import { ExpirationCompleteListerner } from "./events/listeners/expiration-complete-listener";
-import { Listener } from "@sdgittickets/common";
 import { PaymentCreatedListener } from "./events/listeners/payment-created-listener";
 
 const start = async () => {


### PR DESCRIPTION
This pull request includes a small change to the `orders/src/index.ts` file. The change removes an unused import statement for `Listener` from the `@sdgittickets/common` package.

* [`orders/src/index.ts`](diffhunk://#diff-313af4cc72d5f70d72e6dff8b2636db0ab7f12436852bd4e2024b1f750ef6a66L7): Removed the unused import statement for `Listener` from the `@sdgittickets/common` package.